### PR TITLE
fix:

### DIFF
--- a/services/ticket-service/src/main/java/org/opengoofy/index12306/biz/ticketservice/service/handler/ticket/select/TrainSeatTypeSelector.java
+++ b/services/ticket-service/src/main/java/org/opengoofy/index12306/biz/ticketservice/service/handler/ticket/select/TrainSeatTypeSelector.java
@@ -93,13 +93,13 @@ public final class TrainSeatTypeSelector {
             // 查询乘车人信息并赋值
             passengerRemoteResult = userRemoteService.listPassengerQueryByIds(UserContext.getUsername(), passengerIds);
             if (!passengerRemoteResult.isSuccess() || CollUtil.isEmpty(passengerRemoteResultList = passengerRemoteResult.getData())) {
-                throw new RemoteException("用户服务远程调用查询乘车人相信信息错误");
+                throw new RemoteException("用户服务远程调用查询乘车人相关信息错误");
             }
         } catch (Throwable ex) {
             if (ex instanceof RemoteException) {
-                log.error("用户服务远程调用查询乘车人相信信息错误，当前用户：{}，请求参数：{}", UserContext.getUsername(), passengerIds);
+                log.error("用户服务远程调用查询乘车人相关信息错误，当前用户：{}，请求参数：{}", UserContext.getUsername(), passengerIds);
             } else {
-                log.error("用户服务远程调用查询乘车人相信信息错误，当前用户：{}，请求参数：{}", UserContext.getUsername(), passengerIds, ex);
+                log.error("用户服务远程调用查询乘车人相关信息错误，当前用户：{}，请求参数：{}", UserContext.getUsername(), passengerIds, ex);
             }
             throw ex;
         }

--- a/services/ticket-service/src/main/resources/mapper/SeatMapper.xml
+++ b/services/ticket-service/src/main/resources/mapper/SeatMapper.xml
@@ -19,7 +19,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="org.opengoofy.index12306.biz.ticketservice.dao.mapper.SeatMapper">
 
-    <select id="listSeatRemainingTicket" parameterType="org.opengoofy.index12306.biz.ticketservice.dao.entity.SeatDO" resultType="Integer">
+    <select id="listSeatRemainingTicket" parameterType="org.opengoofy.index12306.biz.ticketservice.dao.entity.SeatDO" resultType="java.lang.Integer">
         select count(*) as count
         from t_seat
         where train_id = #{seatDO.trainId}


### PR DESCRIPTION
在SeatMapper.xml中listSeatRemainingTicket方法的resultType不写全路径类名会标红报错.

TrainSeatTypeSelector中的public List<TrainPurchaseTicketRespDTO> select(Integer, PurchaseTicketReqDTO)方法，日志打印中文有错别字.