### PR TITLE
fix：修复购票v2接口可能出现的死锁问题和简化 takeoutStation 方法的相关代码

### DIFF
--- a/services/ticket-service/src/main/java/org/opengoofy/index12306/biz/ticketservice/service/impl/TicketServiceImpl.java
+++ b/services/ticket-service/src/main/java/org/opengoofy/index12306/biz/ticketservice/service/impl/TicketServiceImpl.java
@@ -420,7 +420,7 @@ public class TicketServiceImpl extends ServiceImpl<TicketMapper, TicketDO> imple
         List<RLock> distributedLockList = new ArrayList<>();
         Map<Integer, List<PurchaseTicketPassengerDetailDTO>> seatTypeMap = requestParam.getPassengers().stream()
                 .collect(Collectors.groupingBy(PurchaseTicketPassengerDetailDTO::getSeatType));
-        seatTypeMap.forEach((searType, count) -> {
+        seatTypeMap.keySet().stream().sorted().forEach((searType) -> {
             String lockKey = environment.resolvePlaceholders(String.format(LOCK_PURCHASE_TICKETS_V2, requestParam.getTrainId(), searType));
             ReentrantLock localLock = localLockMap.getIfPresent(lockKey);
             if (localLock == null) {

--- a/services/ticket-service/src/main/java/org/opengoofy/index12306/biz/ticketservice/toolkit/StationCalculateUtil.java
+++ b/services/ticket-service/src/main/java/org/opengoofy/index12306/biz/ticketservice/toolkit/StationCalculateUtil.java
@@ -70,15 +70,15 @@ public final class StationCalculateUtil {
         if (startIndex == -1 || endIndex == -1 || startIndex >= endIndex) {
             return takeoutStationList;
         }
-        if (startIndex != 0) {
-            for (int i = 0; i < startIndex; i++) {
-                for (int j = 1; j < stations.size() - startIndex; j++) {
-                    takeoutStationList.add(new RouteDTO(stations.get(i), stations.get(startIndex + j)));
-                }
+        // 发车在 startStation 之前的 route
+        for (int i = 0; i < startIndex; i++) {
+            for (int j = startIndex + 1; j < stations.size(); j++) {
+                takeoutStationList.add(new RouteDTO(stations.get(i), stations.get(j)));
             }
         }
-        for (int i = startIndex; i <= endIndex; i++) {
-            for (int j = i + 1; j < stations.size() && i < endIndex; j++) {
+        // 发车在 startStation 及之后的 route
+        for (int i = startIndex; i < endIndex; i++) {
+            for (int j = i + 1; j < stations.size(); j++) {
                 takeoutStationList.add(new RouteDTO(stations.get(i), stations.get(j)));
             }
         }


### PR DESCRIPTION
1. Map<Integer, List<PurchaseTicketPassengerDetailDTO>> seatTypeMap = requestParam.getPassengers().stream()
        .collect(Collectors.groupingBy(PurchaseTicketPassengerDetailDTO::getSeatType));
不一定会按照 SeatType 升序排序。所以为了实现顺序加锁，可以先对 key 排序
2.takeoutStation 方法有很多冗余的代码使得可读性较差，所以简化了一些代码