### PR TITLE
Fix UserLoginRespDTO to Use Username for Consistent User Info Query

### DIFF
--- a/services/user-service/src/main/java/org/opengoofy/index12306/biz/userservice/service/impl/UserLoginServiceImpl.java
+++ b/services/user-service/src/main/java/org/opengoofy/index12306/biz/userservice/service/impl/UserLoginServiceImpl.java
@@ -129,7 +129,7 @@ public class UserLoginServiceImpl implements UserLoginService {
                     .realName(userDO.getRealName())
                     .build();
             String accessToken = JWTUtil.generateAccessToken(userInfo);
-            UserLoginRespDTO actual = new UserLoginRespDTO(userInfo.getUserId(), requestParam.getUsernameOrMailOrPhone(), userDO.getRealName(), accessToken);
+            UserLoginRespDTO actual = new UserLoginRespDTO(userInfo.getUserId(), userInfo.getUsername(), userDO.getRealName(), accessToken);
             distributedCache.put(accessToken, JSON.toJSONString(actual), 30, TimeUnit.MINUTES);
             return actual;
         }


### PR DESCRIPTION
Issue

When logging in with a phone number or email via usernameOrMailOrPhone, the UserLoginRespDTO constructor used requestParam.getUsernameOrMailOrPhone() for the username field. This caused a failure to query user information, as the system relies on the username for user info retrieval, and phone numbers or emails are not valid for this purpose.

Changes





Modified the UserLoginRespDTO constructor to use userInfo.getUsername() instead of requestParam.getUsernameOrMailOrPhone() for the username field.



This ensures that the username field always contains the actual username, aligning with the system's user information query logic.

Impact





Fixes the issue where user information could not be retrieved when logging in with a phone number or email.



Ensures consistency in the UserLoginRespDTO response by always returning the username, regardless of the login input (username, phone, or email).

Testing





Verified that login with username, phone number, and email now correctly returns user information in the response.



Confirmed that the username field in UserLoginRespDTO consistently reflects the user's actual username.